### PR TITLE
Allow overriding gateway port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
   taiga-gateway:
     image: nginx:1.19-alpine
     ports:
-      - "9000:80"
+      - "${TAIGA_GATEWAY_PORT:-9000}:80"
     volumes:
       - ./taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
       - taiga-static-data:/taiga/static


### PR DESCRIPTION
This will allow people to deploy taiga without changing this file or creating an override.